### PR TITLE
Add 'http:' to relative urls starting with //

### DIFF
--- a/lib/WebpageAnalyzer.php
+++ b/lib/WebpageAnalyzer.php
@@ -171,6 +171,8 @@ class WebpageAnalyzer
     {
         if (preg_match('#^(https?|ftps?)://#', $href)) {
             return $href;
+        } elseif (substr($href, 0, 2) == '//') {
+            return 'http:'.$href;
         } elseif ($href[0] == '/') {
             return $this->baseUrl.$href;
         } else {


### PR DESCRIPTION
If an image path starts with '//' the url returned from getAbsolutePath() is http://example.com/example.com/image.png, where the image isn't found of course. 

Real life example  is http://www.heise.de/

Hint: if you don't know, what the '//' is for. So files can be opened Independent from the protocol (https vs http) 
